### PR TITLE
Actualizar rutas de imágenes en tourData para la galería de Machu Picchu

### DIFF
--- a/src/data/tourData.ts
+++ b/src/data/tourData.ts
@@ -30,8 +30,8 @@ export const tourData: Tour[] = [
     duration: "1 Día",
     group: "Mín. 10 pax",
     region: "Cusco",
-    image: "/public/images/machupicchu-uno.jpeg",
-    heroImage: "/public/images/machupicchu-hero.jpg",
+    image: "/images/machupicchu-uno.jpeg",
+    heroImage: "/images/machupicchu-hero.jpg",
     highlights: [
       "Tren panorámico",
       "Guía bilingüe",


### PR DESCRIPTION
This pull request makes a small update to the image paths for a tour in the `tourData` array. The change removes the `/public` prefix from the `image` and `heroImage` fields to ensure correct image referencing.

- Updated the `image` and `heroImage` paths in the `tourData` array by removing the `/public` prefix, changing them from `/public/images/...` to `/images/...` (`src/data/tourData.ts`)